### PR TITLE
fixes for both mender and non-mender builds

### DIFF
--- a/conf/machine/odyssey-x86-mender.conf
+++ b/conf/machine/odyssey-x86-mender.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/intel-corei7-64.conf
 
-WKS_FILE = "systemd-bootdisk-initrd.wks"
+WKS_FILE = "systemd-bootdisk-initrd-mender.wks"
 
 WKS_FILE_DEPENDS:append = " acpi-tables"
 

--- a/conf/machine/odyssey-x86.conf
+++ b/conf/machine/odyssey-x86.conf
@@ -11,3 +11,6 @@ WKS_FILE_DEPENDS:append = " acpi-tables"
 # Increase INITRAMFS_MAXSIZE to 384 MiB to cover initramfs-kerneltest-full
 # image.  
 INITRAMFS_MAXSIZE = "393216"
+
+# Temporary fix to have a non-mender build working.
+MENDER_EFI_LOADER = "ovmf"

--- a/wic/systemd-bootdisk-initrd-mender.wks
+++ b/wic/systemd-bootdisk-initrd-mender.wks
@@ -1,0 +1,15 @@
+# short-description: Create an EFI disk image with systemd-boot
+# long-description: Creates a partitioned EFI disk image that the user
+# can directly dd to boot media. The selected bootloader is systemd-boot.
+# It also includes intel-microcode and acpi-tables as an initrd for early update support.
+# Based on OE-core's systemd-bootdisk.wks file.
+
+part /boot --source bootimg-efi --sourceparams="loader=grub-efi,initrd=wic-initrd" --ondisk sda --label msdos --active --align 1024 --use-uuid
+
+part / --source rootfs --ondisk sda --fstype=ext4 --label platform --align 1024 --use-uuid
+
+part swap --ondisk sda --size 44 --label swap1 --fstype=swap --use-uuid
+
+part /data --size 128M --ondisk sda --fstype=ext4 --label data --align 1024 --use-uuid
+
+bootloader --ptable gpt --timeout=5 --append=" rootfstype=ext4 "


### PR DESCRIPTION
- add a mender specific wks file with data partition
- add MENDER_EFI_LOADER to non-mender machine config 